### PR TITLE
Deploy meme-games behind games.kshprenger.com via Ansible

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -1,4 +1,4 @@
-name: Build and Deploy
+name: Build
 
 on:
   push:
@@ -29,29 +29,14 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
-      - name: Upload docker-compose.yml
-        uses: actions/upload-artifact@v4
+      - id: mcp_meta
+        uses: docker/metadata-action@v5
         with:
-          name: docker-compose.yml
-          path: docker-compose.yml
-
-  deploy:
-    needs: build
-    if: ${{ ! contains(github.event.head_commit.message, '[no-deploy]') }}
-    runs-on: self-hosted
-    steps:
-      - name: Download docker-compose.yml
-        uses: actions/download-artifact@v4
+          images: ghcr.io/${{ github.repository_owner }}/meme-games-mcp
+      - uses: docker/build-push-action@v6
         with:
-          name: docker-compose.yml
-
-      - name: Stop and remove old containers
-        run: docker compose down --remove-orphans
-
-      - name: Deploy with Docker Compose
-        run: docker compose up -d
-
-      - name: Clean up
-        if: always()
-        run: |
-          docker image prune -af
+          context: ./mcp_gateway
+          push: true
+          tags: ${{ steps.mcp_meta.outputs.tags }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/README.md
+++ b/README.md
@@ -47,3 +47,5 @@ MCP_GATEWAY_SECRET=replace-private MCP_AUTH_TOKEN=replace-public docker compose 
 Configure MCP clients with the gateway URL and `Authorization: Bearer <MCP_AUTH_TOKEN>`. A host must enable **Allow agents to join** before clients call `join_lobby`; each call returns an independent opaque `player_session`. Agents use that handle for state, actions, events, and leaving. The `wait_for_events` cursor preserves ordered invalidations across reconnects.
 
 Game actions are namespaced (`codenames_*` and `whoami_*`). `get_game_state` returns the receiver-specific state and the exact actions currently available. Who Am I agents join the player circle automatically; human-only question turns stay verbal, while turns involving an agent use structured questions and yes/no/not-sure answers.
+
+Agents can also chat with `lobby_say`; chat lives on the lobby (not the game), so it survives a game switch, and lines show up in the agent's event stream alongside game events.


### PR DESCRIPTION
CI builds and pushes both the app and MCP gateway images to ghcr.io; the self-hosted deploy job is gone since deployment now happens entirely through Ansible. Also documents lobby_say in the README.